### PR TITLE
Implemt Cognito logout (backend testing with localhost)

### DIFF
--- a/backend/MealPlan/src/main/java/Project01/AWS/MealPlan/Configs/SecurityConfig.java
+++ b/backend/MealPlan/src/main/java/Project01/AWS/MealPlan/Configs/SecurityConfig.java
@@ -3,6 +3,7 @@ package Project01.AWS.MealPlan.Configs;
 import Project01.AWS.MealPlan.security.CognitoAuthenticationFailureHandler;
 import Project01.AWS.MealPlan.security.CognitoAuthenticationSuccessHandler;
 import Project01.AWS.MealPlan.security.CognitoLogoutHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -29,8 +30,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, CognitoAuthenticationSuccessHandler cognitoSuccessHandler,
-                                                   CognitoAuthenticationFailureHandler cognitoFailureHandler) throws Exception {
-        CognitoLogoutHandler cognitoLogoutHandler = new CognitoLogoutHandler();
+                                                   CognitoAuthenticationFailureHandler cognitoFailureHandler,  CognitoLogoutHandler cognitoLogoutHandler) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
@@ -52,6 +52,7 @@ public class SecurityConfig {
 //                )
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler(cognitoSuccessHandler)
+//                        .defaultSuccessUrl("/home", true)  // return to this url after success login
                         .failureHandler(cognitoFailureHandler)
                 )
 //                .oauth2Login(Customizer.withDefaults())
@@ -60,10 +61,8 @@ public class SecurityConfig {
                         .invalidateHttpSession(true)
                         .clearAuthentication(true)
                         .deleteCookies("JSESSIONID")
-                        // Attach the custom handler here:
                         .logoutSuccessHandler(cognitoLogoutHandler)
                 )
-//                .formLogin(Customizer.withDefaults())
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/MealPlan/src/main/java/Project01/AWS/MealPlan/security/CognitoLogoutHandler.java
+++ b/backend/MealPlan/src/main/java/Project01/AWS/MealPlan/security/CognitoLogoutHandler.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -18,6 +19,7 @@ import java.nio.charset.StandardCharsets;
  * See more information <a href="https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html">here</a>.
  */
 
+@Component
 public class CognitoLogoutHandler implements LogoutSuccessHandler {
 
     @Value("${aws.cognito.domain}")

--- a/backend/MealPlan/src/main/resources/application.properties
+++ b/backend/MealPlan/src/main/resources/application.properties
@@ -63,8 +63,8 @@ spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:
 spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v3/userinfo
 
 #AWS S3
-cloud.aws.credentials.access-key=
-cloud.aws.credentials.secret-key=
+cloud.aws.credentials.access-key=a
+cloud.aws.credentials.secret-key=a
 cloud.aws.region.static=ap-southeast-1
 aws.s3.bucket-name=meaplan-bucket
 
@@ -73,12 +73,12 @@ ghtk.api.token=a
 ghtk.api.url.fee=https://services.giaohangtietkiem.vn/services/shipment/fee
 
 #AWS Cognito
-spring.security.oauth2.client.registration.cognito.client-id=
-spring.security.oauth2.client.registration.cognito.client-secret=
+spring.security.oauth2.client.registration.cognito.client-id=a
+spring.security.oauth2.client.registration.cognito.client-secret=a
 #spring.security.oauth2.client.registration.cognito.scope=phone,openid,email,profile
 spring.security.oauth2.client.registration.cognito.scope=openid,email,profile
 spring.security.oauth2.client.registration.cognito.redirect-uri=http://localhost:8080/login/oauth2/code/cognito
 spring.security.oauth2.client.provider.cognito.issuer-uri=https://cognito-idp.ap-southeast-1.amazonaws.com/ap-southeast-1_dZcSoYHUp
 spring.security.oauth2.client.provider.cognito.user-name-attribute=username
-aws.cognito.logout-url=http://localhost:8080
+aws.cognito.logout-url=http://localhost:8080/home
 aws.cognito.domain=https://ap-southeast-1dzcsoyhup.auth.ap-southeast-1.amazoncognito.com


### PR DESCRIPTION
Refactored SecurityConfig to inject CognitoLogoutHandler as a bean and annotated CognitoLogoutHandler with @Component for proper dependency injection. Updated application.properties with placeholder AWS and Cognito credentials, and changed the Cognito logout URL to redirect to /home after logout.